### PR TITLE
Deploy all DevOps services for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Assumes:
+- All scripts are run as the root user

--- a/koji-setup/bootstrap-build.sh
+++ b/koji-setup/bootstrap-build.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/parameters.sh
 
+if [[ -n "$SRC_RPM_DIR" && -n "$BIN_RPM_DIR" ]]; then
+	sudo -u kojiadmin koji import "$SRC_RPM_DIR"/*.src.rpm
+	sudo -u kojiadmin koji import "$BIN_RPM_DIR"/*."$RPM_ARCH".rpm
+	if [[ -n "$DEBUG_RPM_DIR" ]]; then
+		sudo -u kojiadmin koji import "$DEBUG_RPM_DIR"/*."$RPM_ARCH".rpm
+	fi
+fi
 sudo -u kojiadmin koji add-tag dist-"$TAG_NAME"
-sudo -u kojiadmin koji add-tag --parent dist-"$TAG_NAME" --arches "x86_64" dist-"$TAG_NAME"-build
 sudo -u kojiadmin koji edit-tag dist-"$TAG_NAME" -x mock.package_manager=dnf
+if [[ -n "$SRC_RPM_DIR" && -n "$BIN_RPM_DIR" ]]; then
+	sudo -u kojiadmin koji list-pkgs --quiet | xargs -I {} sudo -u kojiadmin koji add-pkg --owner kojiadmin dist-"$TAG_NAME" {}
+	sudo -u kojiadmin koji list-untagged | xargs -n 1 -I {} sudo -u kojiadmin koji call tagBuildBypass dist-"$TAG_NAME" {}
+fi
+sudo -u kojiadmin koji add-tag --parent dist-"$TAG_NAME" --arches "$RPM_ARCH" dist-"$TAG_NAME"-build
+sudo -u kojiadmin koji add-target dist-"$TAG_NAME" dist-"$TAG_NAME"-build
 sudo -u kojiadmin koji add-group dist-"$TAG_NAME"-build build
 sudo -u kojiadmin koji add-group dist-"$TAG_NAME"-build srpm-build
-sudo -u kojiadmin koji add-target dist-"$TAG_NAME" dist-"$TAG_NAME"-build
+sudo -u kojiadmin koji add-group-pkg dist-"$TAG_NAME"-build build autoconf automake automake-dev binutils bzip2 clr-rpm-config coreutils diffutils g++ gawk gcc gcc-dev gettext gettext-bin git glibc-dev glibc-locale glibc-utils grep gzip hostname lib6-locale libc6-dev libcap libgcc-s-dev libstdc++-dev libtool libtool-dev linux-libc-headers linux-libc-headers-dev m4 make netbase nss-altfiles patch pigz pkg-config pkg-config-dev rpm-build sed sed-doc shadow systemd-libs tar unzip which xz
+sudo -u kojiadmin koji add-group-pkg dist-"$TAG_NAME"-build srpm-build coreutils cpio curl-bin git glibc-utils grep gzip make pigz rpm-build sed shadow tar unzip wget xz
 if [[ -n "$EXTERNAL_REPO" ]]; then
 	sudo -u kojiadmin koji add-external-repo -t dist-"$TAG_NAME"-build dist-"$TAG_NAME"-external-repo "$EXTERNAL_REPO"
 fi
-sudo -u kojiadmin koji taginfo dist-"$TAG_NAME"-build
-sudo -u kojiadmin koji add-group-pkg dist-"$TAG_NAME"-build build autoconf automake automake-dev binutils bzip2 clr-rpm-config coreutils diffutils g++ gawk gcc gcc-dev gettext gettext-bin git glibc-dev glibc-locale glibc-utils grep gzip hostname lib6-locale libc6-dev libcap libgcc-s-dev libstdc++-dev libtool libtool-dev linux-libc-headers linux-libc-headers-dev m4 make netbase nss-altfiles patch pigz pkg-config pkg-config-dev rpm-build sed sed-doc shadow systemd-libs tar unzip which xz
-sudo -u kojiadmin koji add-group-pkg dist-"$TAG_NAME"-build srpm-build coreutils cpio curl-bin git glibc-utils grep gzip make pigz rpm-build sed shadow tar unzip wget xz
 sudo -u kojiadmin koji regen-repo dist-"$TAG_NAME"-build

--- a/koji-setup/bootstrap-build.sh
+++ b/koji-setup/bootstrap-build.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 if [[ -n "$SRC_RPM_DIR" && -n "$BIN_RPM_DIR" ]]; then

--- a/koji-setup/bootstrap-build.sh
+++ b/koji-setup/bootstrap-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-git.sh
+++ b/koji-setup/deploy-git.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 swupd bundle-add scm-server httpd

--- a/koji-setup/deploy-git.sh
+++ b/koji-setup/deploy-git.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/parameters.sh
+
+swupd bundle-add scm-server httpd
+
+## GITOLITE SETUP
+mkdir -p "$GIT_DIR"
+chown -R "$GIT_USER":"$GIT_USER" "$GIT_DIR"
+# Add symlink for backwards compatibility
+if [[ "$GIT_DIR" != "$GIT_DEFAULT_DIR" ]]; then
+	if [ "$(ls -A "$GIT_DEFAULT_DIR")" ]; then
+		mv "$GIT_DEFAULT_DIR" "$GIT_DEFAULT_DIR".old
+	else
+		rm -rf "$GIT_DEFAULT_DIR"
+	fi
+	ln -sf "$GIT_DIR" "$GIT_DEFAULT_DIR"
+	chown -h "$GIT_USER":"$GIT_USER" "$GIT_DEFAULT_DIR"
+fi
+GITOLITE_PUB_KEY_FILE="$GIT_DEFAULT_DIR/gitolite.pub"
+echo "$GITOLITE_PUB_KEY" > "$GITOLITE_PUB_KEY_FILE"
+chown "$GIT_USER":"$GIT_USER" "$GITOLITE_PUB_KEY_FILE"
+sudo -u "$GIT_USER" gitolite setup -pk "$GITOLITE_PUB_KEY_FILE"
+
+
+if $IS_ANONYMOUS_GIT_NEEDED; then
+	## GIT PROTOCOL CLONING
+	mkdir -p /etc/systemd/system
+	cat > /etc/systemd/system/git-daemon.service <<- EOF
+	[Unit]
+	Description=Git Daemon
+
+	[Service]
+	ExecStart=/usr/bin/git daemon --reuseaddr --base-path=$GIT_DEFAULT_DIR $GIT_DEFAULT_DIR
+
+	Restart=always
+	RestartSec=500ms
+
+	User=$GIT_USER
+	Group=$GIT_USER
+
+	[Install]
+	WantedBy=multi-user.target
+	EOF
+	systemctl daemon-reload
+	systemctl enable --now git-daemon
+
+
+	## CGIT WEB INTERFACE
+	cat > /etc/cgitrc <<- EOF
+	# Enable caching of up to 1000 output entries
+	cache-size=10
+
+	# Specify the css url
+	css=/cgit-data/cgit.css
+
+	# Show extra links for each repository on the index page
+	enable-index-links=1
+
+	# Enable ASCII art commit history graph on the log pages
+	enable-commit-graph=1
+
+	# Show number of affected files per commit on the log pages
+	enable-log-filecount=1
+
+	# Show number of added/removed lines per commit on the log pages
+	enable-log-linecount=1
+
+	# Use a custom logo
+	logo=/cgit-data/cgit.png
+
+	# Enable statistics per week, month and quarter
+	max-stats=quarter
+
+	# Allow download of tar.gz, tar.bz2 and zip-files
+	snapshots=tar.gz tar.bz2
+
+	##
+	## List of common mimetypes
+	##
+	mimetype.gif=image/gif
+	mimetype.html=text/html
+	mimetype.jpg=image/jpeg
+	mimetype.jpeg=image/jpeg
+	mimetype.pdf=application/pdf
+	mimetype.png=image/png
+	mimetype.svg=image/svg+xml
+
+	# Enable syntax highlighting and about formatting
+	source-filter=/usr/libexec/cgit/filters/syntax-highlighting.py
+	about-filter=/usr/libexec/cgit/filters/about-formatting.sh
+
+	##
+	## List of common readmes
+	##
+	readme=:README.md
+	readme=:readme.md
+	readme=:README.mkd
+	readme=:readme.mkd
+	readme=:README.rst
+	readme=:readme.rst
+	readme=:README.html
+	readme=:readme.html
+	readme=:README.htm
+	readme=:readme.htm
+	readme=:README.txt
+	readme=:readme.txt
+	readme=:README
+	readme=:readme
+	readme=:INSTALL.md
+	readme=:install.md
+	readme=:INSTALL.mkd
+	readme=:install.mkd
+	readme=:INSTALL.rst
+	readme=:install.rst
+	readme=:INSTALL.html
+	readme=:install.html
+	readme=:INSTALL.htm
+	readme=:install.htm
+	readme=:INSTALL.txt
+	readme=:install.txt
+	readme=:INSTALL
+	readme=:install
+
+	# Direct cgit to repository location managed by gitolite
+	remove-suffix=1
+	project-list=$GIT_DEFAULT_DIR/projects.list
+	scan-path=$GIT_DEFAULT_DIR/repositories
+	EOF
+
+	mkdir -p /etc/httpd/conf.modules.d
+	cat > /etc/httpd/conf.modules.d/cgid.conf <<- EOF
+	LoadModule cgid_module lib/httpd/modules/mod_cgid.so
+	ScriptSock /run/httpd/cgid.sock
+	EOF
+
+	mkdir -p /etc/httpd/conf.d
+	cat > /etc/httpd/conf.d/cgit.conf <<- EOF
+	Alias /cgit-data /usr/share/cgit
+	<Directory "/usr/share/cgit">
+	    AllowOverride None
+	    Options None
+	    Require all granted
+	</Directory>
+
+	ScriptAlias /cgit /usr/libexec/cgit/cgi-bin/cgit
+	<Directory "/usr/libexec/cgit">
+	    AllowOverride None
+	    Options ExecCGI
+	    Require all granted
+	</Directory>
+	EOF
+	usermod -a -G "$GIT_USER" "$HTTPD_USER"
+
+	systemctl restart httpd
+	systemctl enable httpd
+fi

--- a/koji-setup/deploy-git.sh
+++ b/koji-setup/deploy-git.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-koji-builder.sh
+++ b/koji-setup/deploy-koji-builder.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 # Install kojid

--- a/koji-setup/deploy-koji-builder.sh
+++ b/koji-setup/deploy-koji-builder.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/parameters.sh
+
+# Install kojid
+swupd bundle-add koji
+
+# Create mock folders and permissions
+mkdir -p /etc/mock/koji
+mkdir -p /var/lib/mock
+chown -R root:mock /var/lib/mock
+
+# Setup User Accounts
+useradd -r kojibuilder
+usermod -G mock kojibuilder
+
+# Kojid Configuration Files
+mkdir -p /etc/kojid
+cat > /etc/kojid/kojid.conf <<- EOF
+[kojid]
+sleeptime=5
+maxjobs=16
+topdir=$KOJI_DIR
+workdir=/tmp/koji
+mockdir=/var/lib/mock
+mockuser=kojibuilder
+mockhost=generic-linux-gnu
+user=$KOJI_SLAVE_FQDN
+server=$KOJI_URL/kojihub
+topurl=$KOJI_URL/kojifiles
+use_createrepo_c=True
+allowed_scms=$GIT_FQDN:/packages/*
+cert = $KOJI_PKI_DIR/$KOJI_SLAVE_FQDN.pem
+ca = $KOJI_PKI_DIR/koji_ca_cert.crt
+serverca = $KOJI_PKI_DIR/koji_ca_cert.crt
+EOF
+
+if env | grep -q proxy; then
+	echo "yum_proxy = $https_proxy" >> /etc/kojid/kojid.conf
+	mkdir -p /etc/systemd/system/kojid.service.d
+	cat > /etc/systemd/system/kojid.service.d/00-proxy.conf <<- EOF
+	[Service]
+	Environment=http_proxy=$http_proxy
+	Environment=https_proxy=$https_proxy
+	Environment=no_proxy=$no_proxy
+	EOF
+	systemctl daemon-reload
+fi
+
+systemctl enable --now kojid

--- a/koji-setup/deploy-koji-builder.sh
+++ b/koji-setup/deploy-koji-builder.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-koji-nfs-client.sh
+++ b/koji-setup/deploy-koji-nfs-client.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (C) 2019 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
+source "$SCRIPT_DIR"/parameters.sh
+
+KOJI_MOUNT_DIR=/mnt/koji
+KOJI_MOUNT_SERVICE="${KOJI_MOUNT_DIR:1}"
+KOJI_MOUNT_SERVICE="${KOJI_MOUNT_SERVICE/\//-}".mount
+mkdir -p /etc/systemd/system
+cat > /etc/systemd/system/"$KOJI_MOUNT_SERVICE" <<- EOF
+[Unit]
+Description=Koji NFS Mount
+After=network.target
+
+[Mount]
+What=$KOJI_MASTER_FQDN:$KOJI_DIR
+Where=$KOJI_MOUNT_DIR
+Type=nfs
+Options=defaults,ro
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable --now "$KOJI_MOUNT_SERVICE"

--- a/koji-setup/deploy-koji-nfs-server.sh
+++ b/koji-setup/deploy-koji-nfs-server.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 swupd bundle-add storage-utils

--- a/koji-setup/deploy-koji-nfs-server.sh
+++ b/koji-setup/deploy-koji-nfs-server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/parameters.sh
+
+swupd bundle-add storage-utils
+
+# Export server directory to be mounted by clients
+echo "$KOJI_DIR $KOJI_SLAVE_FQDN(ro)" >> /etc/exports
+
+systemctl enable --now rpcbind
+systemctl enable --now nfs-server

--- a/koji-setup/deploy-koji-nfs-server.sh
+++ b/koji-setup/deploy-koji-nfs-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 # INSTALL KOJI

--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 swupd bundle-add koji

--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/parameters.sh
+
+swupd bundle-add koji
+
+mkdir -p "$MASH_DIR"
+chown -R kojiadmin:kojiadmin "$MASH_DIR"
+mkdir -p "$HTTPD_DOCUMENT_ROOT"
+MASH_LINK="$HTTPD_DOCUMENT_ROOT"/"$(basename "$MASH_DIR")"
+ln -sf "$MASH_DIR"/latest "$MASH_LINK"
+chown -h kojiadmin:kojiadmin "$MASH_LINK"
+usermod -a -G kojiadmin "$HTTPD_USER"
+# Required because Clear is stateless, and mash is run as a non-elevated user
+mkdir -p /var/cache/mash
+rpm --initdb
+
+mkdir -p /etc/mash
+cat > /etc/mash/mash.conf <<- EOF
+[defaults]
+configdir = /etc/mash
+buildhost = $KOJI_URL/kojihub
+repodir = file://$KOJI_DIR
+use_sqlite = True
+use_repoview = False
+EOF
+cat > /etc/mash/clear.mash <<- EOF
+[clear]
+rpm_path = %(arch)s/os/Packages
+repodata_path = %(arch)s/os/
+source_path = source/SRPMS
+debuginfo = True
+multilib = False
+multilib_method = devel
+tag = dist-$TAG_NAME
+inherit = True
+strict_keys = False
+arches = $RPM_ARCH
+EOF
+
+mkdir -p "$MASH_SCRIPT_DIR"
+cp -f "$SCRIPT_DIR"/mash.sh "$MASH_SCRIPT_DIR"
+mkdir -p /etc/systemd/system
+cat > /etc/systemd/system/mash.service <<- EOF
+[Unit]
+Description=Mash script to loop local repository creation for local image builds
+
+[Service]
+User=kojiadmin
+Group=kojiadmin
+ExecStart=$MASH_SCRIPT_DIR/mash.sh
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable --now mash

--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/deploy-upstreams.sh
+++ b/koji-setup/deploy-upstreams.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/parameters.sh
+
+mkdir -p "$UPSTREAMS_DIR"
+chown -R "$GIT_USER":"$GIT_USER" "$UPSTREAMS_DIR"
+mkdir -p "$HTTPD_DOCUMENT_ROOT"
+UPSTREAMS_LINK="$HTTPD_DOCUMENT_ROOT"/"$(basename "$UPSTREAMS_DIR")"
+ln -sf "$UPSTREAMS_DIR" "$UPSTREAMS_LINK"
+chown -h "$GIT_USER":"$GIT_USER" "$UPSTREAMS_LINK"
+usermod -a -G "$GIT_USER" "$HTTPD_USER"

--- a/koji-setup/deploy-upstreams.sh
+++ b/koji-setup/deploy-upstreams.sh
@@ -4,6 +4,7 @@
 
 set -xe
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
 mkdir -p "$UPSTREAMS_DIR"

--- a/koji-setup/deploy-upstreams.sh
+++ b/koji-setup/deploy-upstreams.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/gencert.sh
+++ b/koji-setup/gencert.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# user is equal to parameter one or the first argument when you actually
-# run the script
-user=$1
-# subject is equal to parameter two or the second argument when you actually
-# run the script
-subject="$2"
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
-openssl genrsa -out private/${user}.key 2048
-if [ -z "$subject" ]; then
-	openssl req -config ssl.cnf -new -nodes -out certs/${user}.csr -key private/${user}.key
+KOJI_USER="$1"
+CERT_SUBJECT="$2"
+
+openssl genrsa -out private/"$KOJI_USER".key 2048
+if [ -z "$CERT_SUBJECT" ]; then
+	openssl req -config ssl.cnf -new -nodes -out certs/"$KOJI_USER".csr -key private/"$KOJI_USER".key
 else
-	openssl req -subj "$subject" -config ssl.cnf -new -nodes -out certs/${user}.csr -key private/${user}.key
+	openssl req -subj "$CERT_SUBJECT" -config ssl.cnf -new -nodes -out certs/"$KOJI_USER".csr -key private/"$KOJI_USER".key
 fi
-openssl ca -batch -config ssl.cnf -keyfile private/koji_ca_cert.key -cert koji_ca_cert.crt -out certs/${user}.crt -outdir certs -infiles certs/${user}.csr
-cat certs/${user}.crt private/${user}.key > ${user}.pem
-openssl pkcs12 -export -inkey private/${user}.key -in certs/${user}.crt -CAfile koji_ca_cert.crt -out certs/${user}_browser_cert.p12 -passout pass:
+openssl ca -batch -config ssl.cnf -keyfile private/koji_ca_cert.key -cert koji_ca_cert.crt -out certs/"$KOJI_USER".crt -outdir certs -infiles certs/"$KOJI_USER".csr
+cat certs/"$KOJI_USER".crt private/"$KOJI_USER".key > "$KOJI_USER".pem
+# Browser certificate is not password-protected, ask users to change their password
+openssl pkcs12 -export -inkey private/"$KOJI_USER".key -in certs/"$KOJI_USER".crt -CAfile koji_ca_cert.crt -out certs/"$KOJI_USER"_browser_cert.p12 -passout pass:

--- a/koji-setup/gencert.sh
+++ b/koji-setup/gencert.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 KOJI_USER="$1"

--- a/koji-setup/globals.sh
+++ b/koji-setup/globals.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 #### START DO NOT EDIT ####

--- a/koji-setup/globals.sh
+++ b/koji-setup/globals.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+#### START DO NOT EDIT ####
+export GIT_USER=gitolite
+export GIT_DEFAULT_DIR=/var/lib/gitolite
+
+export POSTGRES_USER=postgres
+export POSTGRES_DEFAULT_DIR=/var/lib/pgsql
+
+export HTTPD_USER=httpd
+export HTTPD_DOCUMENT_ROOT=/var/www/html
+
+export KOJI_PKI_DIR=/etc/pki/koji
+#### END DO NOT EDIT ####

--- a/koji-setup/mash.sh
+++ b/koji-setup/mash.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+if [[ -e /etc/profile.d/proxy.sh ]]; then
+	source /etc/profile.d/proxy.sh
+fi
+
+KOJI_HOME=/srv/koji
+MASH_HOME=/srv/mash
+MASH_TRACKER_FILE="$MASH_HOME"/latest-mash-build
+MASH_DIR="$MASH_HOME"/latest
+MASH_DIR_OLD="$MASH_DIR".old
+MASH_DIR_NEW="$MASH_DIR".new
+
+if [[ -e "$MASH_TRACKER_FILE" ]]; then
+	MASH_BUILD_NUM="$(< "$MASH_TRACKER_FILE")"
+else
+	MASH_BUILD_NUM=0
+fi
+KOJI_BUILD_NUM="$(basename "$(realpath "$KOJI_HOME"/repos/dist-clear-build/latest/)")"
+if [[ "$MASH_BUILD_NUM" -ne "$KOJI_BUILD_NUM" ]]; then
+	COMPS_FILE=$(mktemp)
+	koji show-groups --comps dist-clear-build > "$COMPS_FILE"
+	rm -rf "$MASH_DIR_NEW"
+	mash --outputdir="$MASH_DIR_NEW" --compsfile="$COMPS_FILE" clear
+	rm -f "$COMPS_FILE"
+	dnf -q --repofrompath=mash,file://"$MASH_DIR_NEW"/clear/x86_64/os repoquery -a --queryformat="%{NAME}\t%{VERSION}\t%{RELEASE}" | sort > "$MASH_DIR_NEW"/clear/x86_64/packages-os &>/dev/null
+	dnf -q --repofrompath=mash,file://"$MASH_DIR_NEW"/clear/x86_64/debug repoquery -a --queryformat="%{NAME}\t%{VERSION}\t%{RELEASE}" | sort > "$MASH_DIR_NEW"/clear/x86_64/packages-debug &>/dev/null
+	dnf -q --repofrompath=mash,file://"$MASH_DIR_NEW"/clear/source/SRPMS repoquery -a --queryformat="%{NAME}\t%{VERSION}\t%{RELEASE}" | sort > "$MASH_DIR_NEW"/clear/source/packages-SRPMS &>/dev/null
+	if [[ -e "$MASH_DIR" ]]; then
+		mv "$MASH_DIR" "$MASH_DIR_OLD"
+	fi
+	mv "$MASH_DIR_NEW" "$MASH_DIR"
+	rm -rf "$MASH_DIR_OLD"
+	echo "$KOJI_BUILD_NUM" > "$MASH_TRACKER_FILE"
+fi

--- a/koji-setup/mash.sh
+++ b/koji-setup/mash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -xe

--- a/koji-setup/parameters.sh
+++ b/koji-setup/parameters.sh
@@ -11,12 +11,11 @@ export KOJI_SLAVE_FQDN="$KOJI_MASTER_FQDN"
 export KOJID_CAPACITY=16
 export TAG_NAME=clear
 # Use for koji SSL certificates
-export KOJI_PKI_DIR=/etc/pki/koji
-export COUNTRY_CODE=US
-export STATE=Oregon
-export LOCATION=Hillsboro
+export COUNTRY_CODE='Example Country Code'
+export STATE='Example State'
+export LOCATION='Example Location'
 export ORGANIZATION='Example Organization'
-export ORG_UNIT='Example Unit'
+export ORG_UNIT='Example Org Unit'
 # Use for importing existing RPMs
 export RPM_ARCH='x86_64'
 export SRC_RPM_DIR=
@@ -27,21 +26,12 @@ export EXTERNAL_REPO=https://cdn.download.clearlinux.org/releases/"$(curl https:
 
 ## POSTGRESQL DATABASE
 export POSTGRES_DIR=/srv/pgsql
-export POSTGRES_DEFAULT_DIR=/var/lib/pgsql
-export POSTGRES_USER=postgres
 
 ## GIT REPOSITORIES
 export GIT_DIR=/srv/gitolite
-export GIT_DEFAULT_DIR=/var/lib/gitolite
-export GIT_USER=gitolite
 export GIT_FQDN="$KOJI_MASTER_FQDN"
 export IS_ANONYMOUS_GIT_NEEDED=false
 export GITOLITE_PUB_KEY=''
-
-## APACHE WEB SERVER
-export HTTPD_USER=httpd
-# Autoindexing should occur in this directory by default
-export HTTPD_DOCUMENT_ROOT=/var/www/html
 
 ## UPSTREAMS CACHE
 export UPSTREAMS_DIR=/srv/upstreams

--- a/koji-setup/parameters.sh
+++ b/koji-setup/parameters.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 ## KOJI RPM BUILD AND TRACKER

--- a/koji-setup/parameters.sh
+++ b/koji-setup/parameters.sh
@@ -1,12 +1,51 @@
+#!/bin/bash
+# Copyright (C) 2018 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+## KOJI RPM BUILD AND TRACKER
+export KOJI_DIR=/srv/koji
+export KOJI_MASTER_FQDN="$(hostname -f)"
+export KOJI_URL=https://"$KOJI_MASTER_FQDN"
+export KOJI_MOUNT_DIR=/mnt/koji
+export KOJI_SLAVE_FQDN="$KOJI_MASTER_FQDN"
+export KOJID_CAPACITY=16
+export TAG_NAME=clear
+# Use for koji SSL certificates
+export KOJI_PKI_DIR=/etc/pki/koji
 export COUNTRY_CODE=US
 export STATE=Oregon
 export LOCATION=Hillsboro
-export ORGANIZATION='Example org'
-export ORG_UNIT='Example unit'
-export KOJI_MASTER_FQDN="$(hostname -f)"
-export KOJI_SLAVE_FQDN="$KOJI_MASTER_FQDN"
-export KOJI_DIR=/srv/koji
-export CGIT_FQDN="$KOJI_MASTER_FQDN"
+export ORGANIZATION='Example Organization'
+export ORG_UNIT='Example Unit'
+# Use for importing existing RPMs
+export RPM_ARCH='x86_64'
+export SRC_RPM_DIR=
+export BIN_RPM_DIR=
+export DEBUG_RPM_DIR=
+# Comment the following if supplying all RPMs as an upstream and not a downstream
 export EXTERNAL_REPO=https://cdn.download.clearlinux.org/releases/"$(curl https://download.clearlinux.org/latest)"/clear/\$arch/os/
-export TAG_NAME=clear
-export KOJID_CAPACITY=16
+
+## POSTGRESQL DATABASE
+export POSTGRES_DIR=/srv/pgsql
+export POSTGRES_DEFAULT_DIR=/var/lib/pgsql
+export POSTGRES_USER=postgres
+
+## GIT REPOSITORIES
+export GIT_DIR=/srv/gitolite
+export GIT_DEFAULT_DIR=/var/lib/gitolite
+export GIT_USER=gitolite
+export GIT_FQDN="$KOJI_MASTER_FQDN"
+export IS_ANONYMOUS_GIT_NEEDED=false
+export GITOLITE_PUB_KEY=''
+
+## APACHE WEB SERVER
+export HTTPD_USER=httpd
+# Autoindexing should occur in this directory by default
+export HTTPD_DOCUMENT_ROOT=/var/www/html
+
+## UPSTREAMS CACHE
+export UPSTREAMS_DIR=/srv/upstreams
+
+## MASH RPMS
+export MASH_DIR=/srv/mash
+export MASH_SCRIPT_DIR=/usr/local/bin


### PR DESCRIPTION
A deployment of a "koji" server consists of additional services that
support development beyond koji itself.  These include
git/cgit/gitolite, a mash containing the current snapshot of the
packages in koji, and an upstreams package sources cache.

Because these are required for integration with a DevOps workflow, they
are not included by default in the ansible playbook.