### PR TITLE
Host koji with python3

### DIFF
--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -294,7 +294,6 @@ EOF
 
 mkdir -p /etc/httpd/conf.modules.d
 cat > /etc/httpd/conf.modules.d/wsgi.conf <<- EOF
-LoadModule wsgi_module lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so
 WSGISocketPrefix /run/httpd/wsgi
 EOF
 cat > /etc/httpd/conf.modules.d/ssl.conf <<- EOF


### PR DESCRIPTION
mod_wsgi is built and loaded with python3 by default.  No longer provide
a configuration to load the python2 equivalent, since it is also no
longer included in the koji bundle.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>