### PR TITLE
Conditionally run swupd during setup

### DIFF
--- a/koji-setup/deploy-git.sh
+++ b/koji-setup/deploy-git.sh
@@ -7,7 +7,9 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
-swupd bundle-add scm-server httpd
+swupd bundle-add scm-server || :
+check_dependency gitolite
+check_dependency git
 
 ## GITOLITE SETUP
 mkdir -p "$GIT_DIR"
@@ -29,6 +31,9 @@ sudo -u "$GIT_USER" gitolite setup -pk "$GITOLITE_PUB_KEY_FILE"
 usermod -s /bin/bash gitolite
 
 if $IS_ANONYMOUS_GIT_NEEDED; then
+	swupd bundle-add httpd || :
+	check_dependency httpd
+
 	## GIT PROTOCOL CLONING
 	mkdir -p /etc/systemd/system
 	cat > /etc/systemd/system/git-daemon.service <<- EOF

--- a/koji-setup/deploy-koji-builder.sh
+++ b/koji-setup/deploy-koji-builder.sh
@@ -7,8 +7,8 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
-# Install kojid
-swupd bundle-add koji
+swupd bundle-add koji || :
+check_dependency kojid
 
 # Create mock folders and permissions
 mkdir -p /etc/mock/koji

--- a/koji-setup/deploy-koji-nfs-server.sh
+++ b/koji-setup/deploy-koji-nfs-server.sh
@@ -7,7 +7,9 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
-swupd bundle-add nfs-utils
+swupd bundle-add nfs-utils || :
+check_dependency rpcbind
+check_dependency rpc.nfsd
 
 # Export server directory to be mounted by clients
 echo "$KOJI_DIR $KOJI_SLAVE_FQDN(ro,no_root_squash)" >> /etc/exports

--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -7,8 +7,11 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
-# INSTALL KOJI
-swupd bundle-add koji
+swupd bundle-add koji || :
+check_dependency koji
+check_dependency httpd
+check_dependency kojira
+check_dependency postgres
 
 ## SETTING UP SSL CERTIFICATES FOR AUTHENTICATION
 mkdir -p "$KOJI_PKI_DIR"/{certs,private}

--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -7,7 +7,9 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR"/globals.sh
 source "$SCRIPT_DIR"/parameters.sh
 
-swupd bundle-add koji
+swupd bundle-add package-utils || :
+check_dependency dnf
+check_dependency createrepo_c
 
 mkdir -p "$MASH_DIR"
 chown -R kojiadmin:kojiadmin "$MASH_DIR"

--- a/koji-setup/globals.sh
+++ b/koji-setup/globals.sh
@@ -13,4 +13,16 @@ export HTTPD_USER=httpd
 export HTTPD_DOCUMENT_ROOT=/var/www/html
 
 export KOJI_PKI_DIR=/etc/pki/koji
+
+check_dependency() {
+	if [[ "$#" -ne 1 ]]; then
+		echo "Incorrect number of arguments!" >&2
+		exit 1
+	fi
+	if ! type "$1"; then
+		echo "$1 not found!" >&2
+		exit 1
+	fi
+}
+
 #### END DO NOT EDIT ####


### PR DESCRIPTION
swupd should only be run during setup when on an officially released
version of Clear that has an upadate stream.  Development versions are
usually indicated when the VERSION_ID is equal to 1 and do not have an
update stream.  In these cases, the assumption is that all required
software is already installed prior to setup.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>