### PR TITLE
Do not create mash cache directory

### DIFF
--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -18,8 +18,6 @@ MASH_LINK="$HTTPD_DOCUMENT_ROOT"/"$(basename "$MASH_DIR")"
 ln -sf "$MASH_DIR"/latest "$MASH_LINK"
 chown -h kojiadmin:kojiadmin "$MASH_LINK"
 usermod -a -G kojiadmin "$HTTPD_USER"
-# Required because Clear is stateless, and mash is run as a non-elevated user
-mkdir -p /var/cache/mash
 rpm --initdb
 
 mkdir -p /etc/mash


### PR DESCRIPTION
The mash tool is no longer used, and this directory is no longer needed.
It was only used by this tool.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>