### PR TITLE
Do not set up configurations for mash tool

### DIFF
--- a/koji-setup/deploy-mash.sh
+++ b/koji-setup/deploy-mash.sh
@@ -20,29 +20,6 @@ chown -h kojiadmin:kojiadmin "$MASH_LINK"
 usermod -a -G kojiadmin "$HTTPD_USER"
 rpm --initdb
 
-mkdir -p /etc/mash
-cat > /etc/mash/mash.conf <<- EOF
-[defaults]
-configdir = /etc/mash
-buildhost = $KOJI_URL/kojihub
-repodir = file://$KOJI_DIR
-use_sqlite = True
-use_repoview = False
-EOF
-cat > /etc/mash/clear.mash <<- EOF
-[clear]
-rpm_path = %(arch)s/os/Packages
-repodata_path = %(arch)s/os/
-source_path = source/SRPMS
-debuginfo = True
-multilib = False
-multilib_method = devel
-tag = dist-$TAG_NAME
-inherit = True
-strict_keys = False
-arches = $RPM_ARCH
-EOF
-
 mkdir -p "$MASH_SCRIPT_DIR"
 cp -f "$SCRIPT_DIR"/mash.sh "$MASH_SCRIPT_DIR"
 mkdir -p /etc/systemd/system


### PR DESCRIPTION
The mash tool is no longer used.  So not create stateful configurations
for it.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>