### PR TITLE
Increase SSL config bounds for certificate generation

### DIFF
--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -65,7 +65,7 @@ string_mask             = MASK:0x2002
 [req_distinguished_name]
 countryName                     = Country Name (2 letter code)
 countryName_min                 = 2
-countryName_max                 = 2
+countryName_max                 = 64
 stateOrProvinceName             = State or Province Name (full name)
 localityName                    = Locality Name (eg, city)
 0.organizationName              = Organization Name (eg, company)
@@ -78,7 +78,7 @@ emailAddress_max                = 64
 [req_attributes]
 challengePassword               = A challenge password
 challengePassword_min           = 4
-challengePassword_max           = 20
+challengePassword_max           = 128
 unstructuredName                = An optional company name
 
 [usr_cert]


### PR DESCRIPTION
Supply more reasonable maximum boundaries for country code and challenge
password length.  This allows users to get going without modifying any
values from parameter.sh for SSL certificate generation.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>