### PR TITLE
Remove 'ca' option from configs

### DIFF
--- a/koji-setup/deploy-koji-builder.sh
+++ b/koji-setup/deploy-koji-builder.sh
@@ -41,7 +41,6 @@ topurl=$KOJI_URL/kojifiles
 use_createrepo_c=True
 allowed_scms=$GIT_FQDN:/packages/*
 cert = $KOJI_PKI_DIR/$KOJI_SLAVE_FQDN.pem
-ca = $KOJI_PKI_DIR/koji_ca_cert.crt
 serverca = $KOJI_PKI_DIR/koji_ca_cert.crt
 EOF
 

--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -242,7 +242,6 @@ weburl = $KOJI_URL/koji
 topurl = $KOJI_URL/kojifiles
 topdir = $KOJI_DIR
 cert = ~/.koji/client.crt
-ca = ~/.koji/clientca.crt
 serverca = ~/.koji/serverca.crt
 anon_retry = true
 EOF
@@ -344,7 +343,6 @@ topdir=$KOJI_DIR
 logfile=/var/log/kojira.log
 with_src=no
 cert = $KOJI_PKI_DIR/kojira.pem
-ca = $KOJI_PKI_DIR/koji_ca_cert.crt
 serverca = $KOJI_PKI_DIR/koji_ca_cert.crt
 EOF
 


### PR DESCRIPTION
This option was officially deprecated in koji 1.22.0 and removed in koji 1.24.0. It was internally deprecated a while before 1.22.0, and I've confirmed that removing the config for koji 1.21.2 -- the current version in Clear -- is a no-op.

(Note that removing the 'ca' option from the client config is optional, since unknown options in that config appear to be ignored. But for completeness, I removed it there as well.)