### PR TITLE
Remove unused `with_src` kojira option

### DIFF
--- a/koji-setup/deploy-koji.sh
+++ b/koji-setup/deploy-koji.sh
@@ -341,7 +341,6 @@ cat > /etc/kojira/kojira.conf <<- EOF
 server=$KOJI_URL/kojihub
 topdir=$KOJI_DIR
 logfile=/var/log/kojira.log
-with_src=no
 cert = $KOJI_PKI_DIR/kojira.pem
 serverca = $KOJI_PKI_DIR/koji_ca_cert.crt
 EOF


### PR DESCRIPTION
In koji 1.21.0, kojira began logging a deprecation warning for this option, but it appears to have never had a functional use in the codebase. Avoid the deprecation warning by removing the option from the default config.